### PR TITLE
spec markdown has a section for an abstract, as encouraged by respec.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,3 +1,7 @@
+<section id="abstract">
+Wallet Attached Storage is a system enabling the distributed storage of data spaces and objects from any digital wallet.
+</section>
+
 ## Introduction
 
 The Wallet Attached Storage (WAS) specification brings together the lessons


### PR DESCRIPTION
This seems to also fix the respect html including the markdown. Before this change the table of contents wouldn't show up.